### PR TITLE
Fix byte conversion macros for older Os X releases

### DIFF
--- a/c_src/mmath.h
+++ b/c_src/mmath.h
@@ -1,5 +1,15 @@
-#ifdef SOLARIS
-#include <sys/byteorder.h>
+#if defined(__linux__)
+#  define __USE_BSD
+#  include <stdint.h>
+#  include <endian.h>
+#  define htonll(v) htobe64(v)
+#  define ntohll(v) be64toh(v)
+#elif defined(__APPLE__)
+#  include <libkern/OSByteOrder.h>
+#  define htonll(v) OSSwapHostToBigInt64(v)
+#  define ntohll(v) OSSwapBigToHostInt64(v)
+#elif defined(SOLARIS)
+#  include <sys/byteorder.h>
 #endif
 
 #define IS_SET(v) ((v & 0x00000000000000FFLL) != 0)


### PR DESCRIPTION
(cherry picked from commit 2afb33b0857911d47393b2d3fde812b0a4da1ae9)

Conflicts:
    c_src/mmath.h
