### PR TITLE
Update divide to convert to decimals

### DIFF
--- a/c_src/dec_math.c
+++ b/c_src/dec_math.c
@@ -57,6 +57,25 @@ dec_reduce(decimal *v) {
   }
 }
 
+static inline void
+dec_inflate(decimal *v) {
+  int64_t c = llabs(v->coefficient);
+  if(c == 0) return;
+  // We take some big steps first, to speed things up a little
+  // might not even be needed
+  // I'm sure this can be mathed away.
+  while ((c * 10000) < MAX_COEFFICIENT) {
+    v->coefficient *= 10000;
+    v->exponent -= 4;
+    c *= 10000;
+  }
+  while ((c * 10) < MAX_COEFFICIENT) {
+    v->coefficient *= 10;
+    v->exponent -= 1;
+    c *= 10;
+  }
+}
+
 decimal
 dec_mul(decimal v, int64_t m) {
   // TODO fix in situation when m is so big, that it will overflow coefficient
@@ -71,10 +90,12 @@ dec_mul(decimal v, int64_t m) {
 decimal
 dec_div(decimal v, int64_t m) {
   // TODO: Improve accuracy by adjusting coefficient before dividing
+  dec_inflate(&v);
   decimal r = {
     .coefficient = v.coefficient / m,
     .exponent = v.exponent
   };
+  dec_reduce(&r);
   return r;
 }
 

--- a/eqc/mmath_aggr_eqc.erl
+++ b/eqc/mmath_aggr_eqc.erl
@@ -3,7 +3,7 @@
 -include("../include/mmath.hrl").
 
 -import(mmath_helper,
-        [int_array/0, pos_int/0, non_neg_int/0, defined_int_array/0,
+        [int_array/0, pos_int/0, non_neg_int/0, defined_int_array/0, epsilon/2,
          non_empty_i_list/0, fully_defined_int_array/0, realise/1, realise/3]).
 
 -include_lib("eqc/include/eqc.hrl").
@@ -18,11 +18,11 @@ prop_avg_all() ->
     ?FORALL(L, non_empty_i_list(),
             begin
                 BRes = ?B2L(mmath_aggr:avg(?L2B(L), length(L))),
-                LRes = [round(lists:sum(L) div length(L))],
+                LRes = [lists:sum(L) / length(L)],
                 ?WHENFAIL(
                    io:format(user, "~p =/= ~p~n",
                              [BRes, LRes]),
-                   BRes == LRes)
+                   epsilon(BRes, LRes))
             end).
 
 prop_avg_len() ->
@@ -131,7 +131,7 @@ prop_avg_impl() ->
                 ?WHENFAIL(
                    io:format(user, "~p =/= ~p~n",
                              [LRes, BRes]),
-                   LRes == BRes)
+                   epsilon(LRes, BRes))
             end).
 
 prop_avg_len_undefined() ->
@@ -230,7 +230,7 @@ prop_div_int() ->
             ?WHENFAIL(
                io:format(user, "~p =/= ~p~n",
                          [LRes, BRes]),
-               LRes == BRes)
+               epsilon(LRes, BRes))
             end).
 
 prop_map_int() ->
@@ -280,12 +280,12 @@ prop_combine_sum_r_comp() ->
 prop_combine_avg_N() ->
     ?FORALL({{_, _, A}, N}, {defined_int_array(), pos_int()},
             begin
-                LRes = mmath_aggr:mul(A, 1),
-                BRes = mmath_comb:avg([A || _ <- lists:seq(1, N+1)]),
+                LRes = ?B2L(mmath_aggr:mul(A, 1)),
+                BRes = ?B2L(mmath_comb:avg([A || _ <- lists:seq(1, N+1)])),
                 ?WHENFAIL(
                    io:format(user, "avg(~p*~p) -> ~p =/= ~p~n",
                              [A, N, LRes, BRes]),
-                   LRes == BRes)
+                   epsilon(LRes, BRes))
             end).
 
 prop_combine_avg2_r_comp() ->
@@ -355,10 +355,10 @@ scale_i(L, S) ->
     [round(N*S) || N <- L].
 
 mul_i(L, S) ->
-    [N*S || N <- L].
+    [N * S || N <- L].
 
 div_i(L, S) ->
-    [N div S || N <- L].
+    [N / S || N <- L].
 
 scale_f(L, S) ->
     [N*S || N <- L].
@@ -402,7 +402,7 @@ avg_(L, N) ->
             lists:sum(L);
         Len ->
             lists:sum(L) + (lists:last(L) * (N - Len))
-    end div N.
+    end / N.
 
 sum_(L, N) ->
     case length(L) of

--- a/eqc/mmath_helper.erl
+++ b/eqc/mmath_helper.erl
@@ -5,7 +5,9 @@
 -include("../include/mmath.hrl").
 
 -export([int_array/0, pos_int/0, non_neg_int/0, defined_int_array/0,
-         non_empty_i_list/0, fully_defined_int_array/0, realise/1, realise/3]).
+         non_empty_i_list/0, fully_defined_int_array/0, realise/1, realise/3,
+         epsilon/3, epsilon/2]).
+-define(EPSILON, 0.00001).
 
 defined_int_array() ->
     ?SUCHTHAT({R, _, _}, int_array(), [ok || {true, _} <- R] =/= []).
@@ -62,3 +64,15 @@ realise([{true, V} | R], _, Acc) ->
     realise(R, V, [V | Acc]);
 realise([{false, _} | R], L, Acc) ->
     realise(R, L, [L | Acc]).
+
+epsilon(A, B) ->
+    epsilon(A, B, ?EPSILON).
+
+epsilon(A, B, E) when is_number(A), is_number(B) ->
+    abs(A - B) < E;
+epsilon([A | Ra], [B | Rb], E) ->
+    abs(A - B) < E andalso epsilon(Ra, Rb, E);
+epsilon([], [], _) ->
+    true.
+
+


### PR DESCRIPTION
This improves on the dec_div function, it will 'inflate' the number as far as possible divide it and reduce it back as far as possible. This way 1i/2 results in 0.5f not 1i
